### PR TITLE
Headers: Remove redefinition of __inline

### DIFF
--- a/include/os/rt_linux.h
+++ b/include/os/rt_linux.h
@@ -138,8 +138,6 @@ extern const struct iw_handler_def rt28xx_ap_iw_handler_def;
 /***********************************************************************************
  *	Compiler related definitions
  ***********************************************************************************/
-#undef __inline
-#define __inline static inline
 #define IN
 #define OUT
 #define INOUT

--- a/include/rt_os_net.h
+++ b/include/rt_os_net.h
@@ -57,7 +57,7 @@ PNET_DEV RtmpPhyNetDevMainCreate(void *pAd);
 int rt28xx_close(void *dev);
 int rt28xx_open(void *dev);
 
-__inline int VIRTUAL_IF_UP(void *pAd)
+static inline int VIRTUAL_IF_UP(void *pAd)
 {
 	RT_CMD_INF_UP_DOWN InfConf = { rt28xx_open, rt28xx_close };
 	if (RTMP_COM_IoctlHandle(pAd, CMD_RTPRIV_IOCTL_VIRTUAL_INF_UP,
@@ -66,7 +66,7 @@ __inline int VIRTUAL_IF_UP(void *pAd)
 	return 0;
 }
 
-__inline void VIRTUAL_IF_DOWN(void *pAd)
+static inline void VIRTUAL_IF_DOWN(void *pAd)
 {
 	RT_CMD_INF_UP_DOWN InfConf = { rt28xx_open, rt28xx_close };
 	RTMP_COM_IoctlHandle(pAd, CMD_RTPRIV_IOCTL_VIRTUAL_INF_DOWN,

--- a/tx_rx/include/os/rt_linux.h
+++ b/tx_rx/include/os/rt_linux.h
@@ -138,8 +138,6 @@ extern const struct iw_handler_def rt28xx_ap_iw_handler_def;
 /***********************************************************************************
  *	Compiler related definitions
  ***********************************************************************************/
-#undef __inline
-#define __inline static inline
 #define IN
 #define OUT
 #define INOUT

--- a/tx_rx/include/rt_os_net.h
+++ b/tx_rx/include/rt_os_net.h
@@ -57,7 +57,7 @@ PNET_DEV RtmpPhyNetDevMainCreate(void *pAd);
 int rt28xx_close(void *dev);
 int rt28xx_open(void *dev);
 
-__inline int VIRTUAL_IF_UP(void *pAd)
+static inline int VIRTUAL_IF_UP(void *pAd)
 {
 	RT_CMD_INF_UP_DOWN InfConf = { rt28xx_open, rt28xx_close };
 	if (RTMP_COM_IoctlHandle(pAd, CMD_RTPRIV_IOCTL_VIRTUAL_INF_UP,
@@ -66,7 +66,7 @@ __inline int VIRTUAL_IF_UP(void *pAd)
 	return 0;
 }
 
-__inline void VIRTUAL_IF_DOWN(void *pAd)
+static inline void VIRTUAL_IF_DOWN(void *pAd)
 {
 	RT_CMD_INF_UP_DOWN InfConf = { rt28xx_open, rt28xx_close };
 	RTMP_COM_IoctlHandle(pAd, CMD_RTPRIV_IOCTL_VIRTUAL_INF_DOWN,


### PR DESCRIPTION
__inline is a compiler built-in and should not be redefined. Redefining it causes weird error messages.

Fixes #5.