### PR TITLE
Fixed cloning URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Linux kernel version up to 5.0.5 has been tested.
 
 To build the driver, follow these steps:
 
-    $ git clone https://github.com/kaduke/Netgear-A6210
+    $ git clone https://github.com/Netgear-A6210-linux-driver/Netgear-A6210.git
     $ cd Netgear-A6210
     $ make
     $ sudo make install


### PR DESCRIPTION
It was pointing to an old repo (fork?). Just changed it to the current repository, with so many copies of this going around this was the one thing keeping me from having this work in my machine. An easy thing to overlook, especially by a user who's just copying and pasting.