### PR TITLE
modify usb_main_dev.c #507 for newer kernel

### DIFF
--- a/os/linux/usb_main_dev.c
+++ b/os/linux/usb_main_dev.c
@@ -496,8 +496,6 @@ static struct dentry *dbgfs_dir = 0;
 int __init rtusb_init(void)
 {
 #ifdef DBG
-	struct dentry *tmp;
-
 	printk("rtusb init %s --->\n", RTMP_DRV_NAME);
 	dbgfs_dir = debugfs_create_dir(RTMP_DRV_NAME, 0);
 	if (!dbgfs_dir) {
@@ -505,11 +503,6 @@ int __init rtusb_init(void)
 	}
 
 	debugfs_create_u32("RTDebugLevel", S_IWUSR | S_IRUGO, dbgfs_dir, &RTDebugLevel);
-//      because debugfs_create_u32  return void in new kernel. 
-//	tmp = debugfs_create_u32("RTDebugLevel", S_IWUSR | S_IRUGO, dbgfs_dir, &RTDebugLevel);
-//	if (!tmp) {
-//		printk(KERN_ALERT "debugfs_create_u32 failed\n");
-//	}
 #endif
 	return usb_register(&rtusb_driver);
 }

--- a/os/linux/usb_main_dev.c
+++ b/os/linux/usb_main_dev.c
@@ -504,11 +504,12 @@ int __init rtusb_init(void)
 		printk(KERN_ALERT "debugfs_create_dir failed\n");
 	}
 
-	tmp = debugfs_create_u32("RTDebugLevel", S_IWUSR | S_IRUGO, dbgfs_dir,
-			&RTDebugLevel);
-	if (!tmp) {
-		printk(KERN_ALERT "debugfs_create_u32 failed\n");
-	}
+	debugfs_create_u32("RTDebugLevel", S_IWUSR | S_IRUGO, dbgfs_dir, &RTDebugLevel);
+//      because debugfs_create_u32  return void in new kernel. 
+//	tmp = debugfs_create_u32("RTDebugLevel", S_IWUSR | S_IRUGO, dbgfs_dir, &RTDebugLevel);
+//	if (!tmp) {
+//		printk(KERN_ALERT "debugfs_create_u32 failed\n");
+//	}
 #endif
 	return usb_register(&rtusb_driver);
 }


### PR DESCRIPTION
newer kernel had changed the return of "debugfs_create_u32" to void.