### PR TITLE
Updated to reflect kernel changes made in 5.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This driver supports Ralink / Mediatek mt766u, mt7632u and mt7612u chipsets.
 In particular, the driver supports several USB dongles such as Netgear-A6210,
 ASUS USB-AC55, ASUS USB-N53 and EDUP EP-AC1601.
 
-Linux kernel version up to 5.7.19 has been tested.
+Linux kernel version up to 5.8.0 has been tested
 
 ## Building
 

--- a/os/linux/cfg80211/cfg80211.c
+++ b/os/linux/cfg80211/cfg80211.c
@@ -1731,15 +1731,26 @@ static int CFG80211_OpsRemainOnChannel(struct wiphy *pWiphy,
 
 static void CFG80211_OpsMgmtFrameRegister(
 	struct wiphy *pWiphy,
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(3,6,0))
+	struct net_device *dev,
+#endif /*LINUX_VERSION_CODE: < 3.6.0 */
+
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,6,0))
 	struct wireless_dev *wdev,
-#else
-	struct net_device *dev,
 #endif /* LINUX_VERSION_CODE: 3.6.0 */
-	u16 frame_type, bool reg)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,8,0))
+	struct mgmt_frame_regs *upd
+#else 
+	u16 frame_type, bool reg
+#endif
+	)
 {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,6,0))
 	struct net_device *dev;
+#endif
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,8,0))
+	bool reg = true;
+	u16 frame_type = (upd -> interface_stypes);
 #endif
 	void *pAd;
 
@@ -2500,7 +2511,9 @@ static struct cfg80211_ops CFG80211_Ops = {
 	.set_cqm_rssi_config	= NULL,
 #endif /* LINUX_VERSION_CODE */
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,37))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,8,0))
+	.update_mgmt_frame_registrations = CFG80211_OpsMgmtFrameRegister,
+#elif (LINUX_VERSION_CODE > KERNEL_VERSION(2,6,37))
 	/* notify driver that a management frame type was registered */
 	.mgmt_frame_register	= CFG80211_OpsMgmtFrameRegister,
 #endif /* LINUX_VERSION_CODE */


### PR DESCRIPTION
cfg80211.c was edited to reflect the change in Linux kernel 5.8 from using mgmt_frame_register to update_mgmt_frame_registration in cfg80211_ops. Tested on Linux kernel 5.4 and 5.8.